### PR TITLE
moved gameinfo, sytle selectors and eval depth button. gameinfo expandable. added remove safed pgns button. console is now collapsible. pvLines is now collapsible. add pgn is now also back in the menubar.faulty move history coloring fixed. quicktoor button added in menubar

### DIFF
--- a/src/renderer/components/AnalysisView.vue
+++ b/src/renderer/components/AnalysisView.vue
@@ -25,7 +25,6 @@
       @move-forward-one="$emit('move-forward-one', 0)"
       @move-to-end="$emit('move-to-end', 0)"
     />
-    <GameInfo id="gameinfo" />
     <EngineConsole />
   </div>
 </template>
@@ -37,14 +36,13 @@ import AnalysisEvalRow from './AnalysisEvalRow'
 import JumpButtons from './JumpButtons'
 import EngineStats from './EngineStats'
 import PVLines from './PVLines'
-import GameInfo from './GameInfo'
 import EngineConsole from './EngineConsole'
 import MoveHistoryNode from './MoveHistoryNode'
 
 export default {
   name: 'AnalysisView',
   components: {
-    AnalysisHead, AnalysisEvalRow, JumpButtons, EngineStats, PVLines, GameInfo, EngineConsole, MoveHistoryNode
+    AnalysisHead, AnalysisEvalRow, JumpButtons, EngineStats, PVLines, EngineConsole, MoveHistoryNode
   },
   computed: {
     ...mapGetters(['active', 'mainFirstMove']),
@@ -126,13 +124,6 @@ input {
   }
 }
 
-#gameinfo {
-  height: auto;
-  margin: 1em 0em;
-  border: 1px solid var(--main-border-color);
-  border-radius: 5px;
-  background-color: var(--second-bg-color);
-}
 #move-history {
   text-align: left;
 }

--- a/src/renderer/components/DarkModeSwitch.vue
+++ b/src/renderer/components/DarkModeSwitch.vue
@@ -29,7 +29,7 @@ export default {
         document.documentElement.style.setProperty('--scroll-track-color', '#32363b')
         document.documentElement.style.setProperty('--scroll-thumb-color', '#23272a')
         document.documentElement.style.setProperty('--variation-color', '#99aab5')
-        document.documentElement.style.setProperty('--tooltip-color', '#99aab5')
+        document.documentElement.style.setProperty('--tooltip-color', '#40434a')
         document.documentElement.style.setProperty('--button-color', '#535a6e')
         document.documentElement.style.setProperty('--hover-color', '#99aab5')
         document.documentElement.style.setProperty('--highlight-color', '#7289da')

--- a/src/renderer/components/EngineConsole.vue
+++ b/src/renderer/components/EngineConsole.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="container">
     <div
+      v-show="showConsole"
       ref="scroller"
       class="console"
       @scroll.passive="onScroll"
@@ -32,13 +33,29 @@
         Jump to bottom
       </div>
     </div>
-    <input
-      v-model="input"
-      class="input"
-      type="text"
-      size="60"
-      @keyup="onKeyup"
-    >
+    <div class="consoleInput">
+      <input
+        v-model="input"
+        class="input"
+        type="text"
+        size="60"
+        placeholder="Console Input"
+        @keyup="onKeyup"
+      >
+      <div
+        class="collapsible"
+        @click="toggle"
+      >
+        <em
+          v-show="showExpandIcon"
+          class="icon mdi mdi-arrow-expand-down"
+        />
+        <em
+          v-show="showMinimizeIcon"
+          class="icon mdi mdi-arrow-expand-up"
+        />
+      </div>
+    </div>
   </div>
 </template>
 
@@ -63,7 +80,10 @@ export default {
       fullWidth: 0,
       renderLength: 0,
       autoScroll: true,
-      scrollbarSize: 0
+      scrollbarSize: 0,
+      showConsole: true, // Flag to show Console
+      showExpandIcon: false, // Flag to show expand-down icon
+      showMinimizeIcon: true // Flag to show expand-up icon
     }
   },
   computed: {
@@ -93,6 +113,11 @@ export default {
     this.scrollbarSize = scroller.offsetHeight - scroller.clientHeight
   },
   methods: {
+    toggle () {
+      this.showConsole = !this.showConsole
+      this.showExpandIcon = !this.showExpandIcon
+      this.showMinimizeIcon = !this.showMinimizeIcon
+    },
     getScrollTopMax () {
       const { scroller } = this.$refs
       return scroller.scrollHeight - scroller.clientHeight
@@ -211,9 +236,33 @@ export default {
 .button.visible {
   display: block;
 }
+
+.consoleInput {
+  display: flex;
+}
+
 .input {
+  flex-grow: 1;
   outline: none;
   border: 1px solid var(--main-border-color);
   background-color: var(--second-bg-color);
+}
+.collapsible {
+  color: var(--light-text-color);
+  background-color: var(--button-color);
+  padding: 1px;
+  border: 2px solid var(--main-border-color);
+  text-decoration: none;
+  cursor: pointer;
+  width: 20px;
+  border: none;
+  text-align: right;
+  outline: none;
+  font-size: 12px;
+  text-align: center;
+}
+
+.collapsible:hover {
+  background-color: var(--hover-color);
 }
 </style>

--- a/src/renderer/components/EvalPlotButton.vue
+++ b/src/renderer/components/EvalPlotButton.vue
@@ -79,10 +79,10 @@ input::-webkit-inner-spin-button {
 .inputDepth {
   position: relative;
   display: inline-block;
-  width: 50px;
+  width: 40px;
 }
 .inputField {
-  width: 30px;
+  width: 25px;
   background-color: var(--second-bg-color);
   color: var(--main-text-color);
 }
@@ -90,8 +90,8 @@ input::-webkit-inner-spin-button {
   color: var(--main-text-color);
 }
 .button {
-  padding: 5px;
-  border-radius: 5px;
+  padding: 3px;
+  border-radius: 3px;
   background-color:var(--button-color);
   color: white;
   box-shadow: 1px 1px 1px 1px black;
@@ -104,8 +104,6 @@ input::-webkit-inner-spin-button {
 .EvalPlotButton {
   display: inline-block;
   position: relative;
-  padding-top: 5px;
-  padding-left: 10px;
 }
 .EvalPlotButton::before{
   content: attr(data-text);

--- a/src/renderer/components/GameBoards.vue
+++ b/src/renderer/components/GameBoards.vue
@@ -5,15 +5,21 @@
       <div class="main-grid">
         <div class="chessboard-grid">
           <PgnBrowser id="pgnbrowser" />
-          <div class="board">
-            <div @mousewheel.prevent.exact="scroll($event)">
-              <ChessGround
-                id="chessboard"
-                :orientation="orientation"
-                @onMove="showInfo"
-              />
+          <div class="board-grid">
+            <div class="board">
+              <span><GameInfo id="gameinfo" /></span>
+              <div
+                class="scrollable"
+                @mousewheel.prevent.exact="scroll($event)"
+              >
+                <ChessGround
+                  id="chessboard"
+                  :orientation="orientation"
+                  @onMove="showInfo"
+                />
+              </div>
+              <EvalBar class="evalbar" />
             </div>
-            <EvalBar class="evalbar" />
           </div>
           <div id="fen-field">
             FEN <input
@@ -67,8 +73,7 @@ import Vue from 'vue'
 import PgnBrowser from './PgnBrowser.vue'
 import SettingsTab from './SettingsTab'
 import EvalPlotButton from './EvalPlotButton'
-// TODO: use GameInfo component?
-// import GameInfo from './GameInfo.vue'
+import GameInfo from './GameInfo.vue'
 
 export default {
   name: 'GameBoards',
@@ -79,7 +84,7 @@ export default {
     PieceStyleSelector,
     BoardStyleSelector,
     EvalPlot,
-    // GameInfo,
+    GameInfo,
     PgnBrowser,
     SettingsTab,
     EvalPlotButton
@@ -327,11 +332,28 @@ export default {
   grid-area: chessboard;
   display: grid;
   grid-template-columns: 20% auto;
-  grid-template-rows: auto auto auto;
+  grid-template-rows: 80% auto auto;
   grid-template-areas:
-    "pgnbrowser ."
-    ". fenfield"
-    ". selector";
+    "pgnbrowser board-grid"
+    "selector board-grid "
+    ". fenfield";
+}
+
+.board-grid {
+  grid-area: board-grid;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+
+#gameinfo {
+  grid-area: gameinfo;
+  height: auto;
+  border: 1px solid var(--main-border-color);
+  margin-bottom: 5px;
+  margin-left: 5px;
+  border-radius: 5px;
+  background-color: var(--second-bg-color);
 }
 #analysisview {
   grid-area: analysisview;
@@ -360,10 +382,11 @@ input {
 #selector-container {
   grid-area: selector;
   display: grid;
-  grid-template-columns: 5% 30% 5% 30%  30%;
   grid-template-areas:
-  ". piecestyle . boardstyle evalButton";
-  height: 60px;
+  "piecestyle"
+  "boardstyle"
+  "evalButton";
+  margin-left: 5px;
 }
 #piece-style {
   grid-area: piecestyle;
@@ -379,13 +402,24 @@ input {
   grid-area: pgnbrowser;
   border: 1px solid var(--main-border-color);
   border-radius: 4px;
-  margin-left: 1em;
-  max-height: 60vh;
+  margin-left: 5px;
+  max-height: 700vh;
 }
-.board {
+
+.scrollable {
+  grid-area: scrollable;
   display: flex;
   flex-direction: row;
   justify-content: center;
+  width: max-content
+}
+
+.board {
+  grid-area: board;
+  display: grid;
+  grid-template-areas:
+  "gameinfo ."
+  "scrollable evalbar";
 }
 #chessboard {
   display: inline-block;
@@ -398,6 +432,7 @@ input {
   margin: 0 auto;
 }
 .evalbar {
+  grid-area: evalbar;
   margin-left: 8px;
   height: 99%;
 }

--- a/src/renderer/components/GameInfo.vue
+++ b/src/renderer/components/GameInfo.vue
@@ -18,8 +18,24 @@
         class="player"
         style="text-align: right"
       />
+      <div
+        class="collapsible"
+        @click="toggle"
+      >
+        <em
+          v-show="showExpandIcon"
+          class="icon mdi mdi-arrow-expand-down"
+        />
+        <em
+          v-show="showMinimizeIcon"
+          class="icon mdi mdi-arrow-expand-up"
+        />
+      </div>
     </div>
-    <div id="metainfo">
+    <div
+      v-show="showSection"
+      id="metainfo"
+    >
       <p>
         Event: {{ eventName ? eventName : 'unknown' }} <span v-if="eventSite"> (@ {{ eventSite }})</span>
         <span v-if="round && /\d+/gm.test(round)"> round {{ round }} </span>
@@ -36,6 +52,13 @@ import PlayerInfo from './PlayerInfo.vue'
 export default {
   name: 'GameInfo',
   components: { PlayerInfo },
+  data () {
+    return {
+      showSection: false, // Flag to show MetaInfo
+      showExpandIcon: true, // Flag to show expand-down icon
+      showMinimizeIcon: false // Flag to show expand-up icon
+    }
+  },
   computed: {
     gameInfo () {
       return this.$store.getters.gameInfo
@@ -86,8 +109,14 @@ export default {
     round () {
       return this.gameInfo.Round
     }
+  },
+  methods: {
+    toggle () { // Flips Flags
+      this.showSection = !this.showSection
+      this.showExpandIcon = !this.showExpandIcon
+      this.showMinimizeIcon = !this.showMinimizeIcon
+    }
   }
-
 }
 </script>
 <style scoped>
@@ -101,13 +130,28 @@ export default {
   border-bottom: 1px solid var(--main-border-color);
 }
 
-#gameinfo {
-  padding: 0.3em;
-}
-
 #metainfo {
   font-size: 10pt;
   font-weight: 200;
   text-align: left;
+}
+
+.collapsible {
+  color: var(--light-text-color);
+  background-color: var(--button-color);
+  padding: 1px;
+  border: 2px solid var(--main-border-color);
+  text-decoration: none;
+  cursor: pointer;
+  width: 20px;
+  border: none;
+  text-align: center;
+  outline: none;
+  font-size: 12px;
+  text-align: center;
+}
+
+.active, .collapsible:hover {
+  background-color: var(--hover-color);
 }
 </style>

--- a/src/renderer/components/LandingPage.vue
+++ b/src/renderer/components/LandingPage.vue
@@ -53,6 +53,6 @@ body { font-family: Avenir, Helvetica, Arial, sans-serif; }
 
 #menubar {
   text-align: center;
-  margin-bottom: 10px;
+  margin-bottom: 5px;
 }
 </style>

--- a/src/renderer/components/MenuBar.vue
+++ b/src/renderer/components/MenuBar.vue
@@ -9,6 +9,18 @@
     </div>
     <div
       class="item"
+      @click="openPgn"
+    >
+      <em class="icon mdi mdi-checkerboard" /> Open PGN
+    </div>
+    <div
+      class="item"
+      @click="startQuickTour"
+    >
+      <em class="icon mdi mdi-map-search" /> Quickguide
+    </div>
+    <div
+      class="item"
       @click="openAboutTabModal"
     >
       <em class="icon mdi mdi-information-outline" /> About <em class="icon mdi mdi-github" />
@@ -22,7 +34,9 @@
 </template>
 
 <script>
+import fs from 'fs'
 import { mapGetters } from 'vuex'
+import ffish from 'ffish'
 import AboutTabModal from './AboutTabModal'
 
 export default {
@@ -34,15 +48,87 @@ export default {
         visible: false,
         title: '',
         save: () => {}
-      }
+      },
+      error: 'none',
+      pgnString: ''
     }
   },
   computed: {
-    ...mapGetters(['viewAnalysis', 'variantOptions'])
+    ...mapGetters(['viewAnalysis', 'initialized', 'variantOptions'])
   },
   methods: {
     changeTab () {
       this.$store.commit('viewAnalysis', !this.viewAnalysis)
+    },
+    openPgn () {
+      this.$electron.remote.dialog.showOpenDialog({
+        title: 'Open PGN file',
+        properties: ['openFile'],
+        filters: [
+          { name: 'PGN Files', extensions: ['pgn'] },
+          { name: 'All Files', extensions: ['*'] }
+        ]
+      }).then(result => {
+        if (!result.canceled) {
+          localStorage.PGNPath = JSON.stringify(result.filePaths[0])
+          this.openPGNFromPath(result.filePaths[0])
+        }
+      }).catch(err => {
+        console.log(err)
+      })
+    },
+    openPGNFromPath (path) {
+      fs.readFile(path, 'utf8', (err, data) => {
+        if (err) {
+          return console.log(err)
+        }
+
+        // convert CRLF to LF
+        data = data.replace(/\r\n/g, '\n')
+        this.convertAndStorePgn(data)
+      })
+    },
+    convertAndStorePgn (data) {
+      const regex = /(?:\[.+ ".*"\]\r?\n)+\r?\n+(?:.+\r?\n)*/gm
+      let games = []
+      if (this.$store.getters.loadedGames) {
+        games = this.$store.getters.loadedGames
+      }
+      let numOfUnparseableGames = 0
+      let m
+      const maxGames = 30
+      let currentGameCount = 0
+      while ((m = regex.exec(data)) !== null && currentGameCount !== maxGames) {
+        if (m.index === regex.lastIndex) {
+          regex.lastIndex++
+        }
+        m.forEach((match, groupIndex) => {
+          let game
+          try {
+            game = ffish.readGamePGN(match)
+          } catch (error) {
+            numOfUnparseableGames = numOfUnparseableGames + 1
+            return
+          }
+          currentGameCount++
+          games.push(game)
+        })
+      }
+
+      if (numOfUnparseableGames !== 0) {
+        alert(numOfUnparseableGames + ' games could not be parsed.')
+      }
+
+      games = games.map((curVal, idx, arr) => {
+        curVal.id = idx
+        curVal.supported = this.variantOptions.revGet(curVal.headers('Variant').toLowerCase()) !== undefined || !curVal.headers('Variant')
+        return curVal
+      })
+
+      this.$store.dispatch('loadedGames', games)
+    },
+    startQuickTour () {
+
     },
     openAboutTabModal () {
       this.modal = {
@@ -61,17 +147,16 @@ export default {
   font-size: 11px;
   width: 100%;
   display: flex;
+  justify-content: flex-end
 }
 .item {
-  padding-left: 16px;
-  padding-right: 16px;
+  padding-left: 20px;
+  padding-right: 20px;
   padding-top: 1px;
   padding-bottom: 1px;
-  text-align: left;
   display: inline-block;
   color: var(--light-text-color);;
-  font-size: 11px;
-  text-decoration: none;
+  font-size: 14px;
   cursor: pointer;
 }
 .item:hover {

--- a/src/renderer/components/MoveHistoryNode.vue
+++ b/src/renderer/components/MoveHistoryNode.vue
@@ -315,7 +315,7 @@ export default {
   color: var(--light-text-color);
 }
 .move-number {
-  color: var(--light-text-color);
+  color: var(--main-text-color);
 }
 .move-name {
   margin-right: 4px;

--- a/src/renderer/components/PgnBrowser.vue
+++ b/src/renderer/components/PgnBrowser.vue
@@ -84,6 +84,12 @@
         </div>
       </template>
     </div>
+    <div
+      class="footer"
+      @click="removeSafedPGN"
+    >
+      <em class="icon mdi mdi-trash-can-outline" />
+    </div>
   </div>
 </template>
 
@@ -220,6 +226,16 @@ export default {
         visible: true,
         title: 'Add new PGN'
       }
+    },
+    removeSafedPGN () {
+      if (confirm('Do you really want to remove the safed PGNs and reset the board?')) {
+        document.dispatchEvent(new Event('resetPlot'))
+        this.$store.dispatch('resetBoard', { is960: false }) // used to exit 960 Mode
+      }
+      if (this.$store.getters.loadedGames) {
+        const games = []
+        this.$store.dispatch('loadedGames', games)
+      }
     }
   }
 }
@@ -229,7 +245,7 @@ export default {
 #gameselect {
   overflow-y: auto;
   overflow-x: auto;
-  height: 100%;
+  height: 96%;
   border: 0px solid var(--main-border-color);
 }
 
@@ -287,6 +303,19 @@ export default {
   padding: 2px 2px;
   white-space: nowrap;
   width: 100%;
+}
+
+.footer {
+  border-top: 1px solid var(--main-border-color);
+  background-color: var(--button-color);
+  height: 4%;
+}
+.footer:hover {
+  background-color: var(--hover-color);
+}
+.icon.mdi-trash-can-outline {
+  font-size: 100%;
+
 }
 
 .unsupported {


### PR DESCRIPTION
# Purpose
_Describe the feature or solved problems_

# Pre-merge TODOs and Checks 
- [x] _(exclude checks that are not relevant for your feature)_
- [x] PGN file loads correctly
- [x] Navigating through the move history works
- [x] Starting the engine shows moves (test for both sides)
- [x] Selecting a different variant loads a new board with the variant and you can make moves on the board
- [x] In Crazyhouse the pocket pieces are shown and you can drop pieces
